### PR TITLE
ensure latest_version isn't null (when http request fails or something) before updating in the file

### DIFF
--- a/.github/workflows/latest-versions.yml
+++ b/.github/workflows/latest-versions.yml
@@ -21,8 +21,12 @@ jobs:
 
       - name: Discover latest version
         run: |
-          curl -sL https://api.github.com/repos/vector-im/element-web/releases/latest | \
-          jq -r ".tag_name" > latest-versions/element
+          latest_version=$(curl -sL https://api.github.com/repos/vector-im/element-web/releases/latest | \
+          jq -r ".tag_name")
+          if [ $latest_version != "null" ]
+          then
+            echo $latest_version > latest-versions/element
+          fi
 
       - name: Check for modified files
         id: git-check


### PR DESCRIPTION
When http request for checking latest version fails for whatever reasons or is empty body, `jq` returns `null` for unknown field.

In https://github.com/Automattic/chat.a8c.com/commit/d344e6e4a61e054dff9c4de1ed02225c3a629328 something of the sort happened and it updated the version to `null`. So with this PR, now we check for value returned by `jq` before acting on it.

