### PR TITLE
ensure valid latest_version value for matrix.to

### DIFF
--- a/.github/workflows/latest-versions.yml
+++ b/.github/workflows/latest-versions.yml
@@ -57,8 +57,12 @@ jobs:
 
       - name: Discover latest version
         run: |
-          curl -sL https://api.github.com/repos/Automattic/matrix.to/releases/latest | \
-          jq -r ".tag_name" > latest-versions/matrix.to
+          latest_version=$(curl -sL https://api.github.com/repos/Automattic/matrix.to/releases/latest | \
+          jq -r ".tag_name")
+          if [ $latest_version != "null" ]
+          then
+            echo $latest_version > latest-versions/matrix.to
+          fi
 
       - name: Check for modified files
         id: git-check


### PR DESCRIPTION
http failure can cause the latest_version to be set as `null`, so check for that before updating in the file